### PR TITLE
remove version specifier on redis

### DIFF
--- a/historedis.gemspec
+++ b/historedis.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency             "redis", "~> 3.3.5"
+  spec.add_dependency             "redis"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "fakeredis", "~> 0.7.0"


### PR DESCRIPTION
Following the way other gems work - https://github.com/dv/redis-semaphore/blob/master/redis-semaphore.gemspec#L15

This way consumer apps can use whatever redis they want.